### PR TITLE
feat(gptchangelog):  update load_openai_config to return base_url from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ model = gpt-4o
 ```
 Replace `your_openai_api_key_here` with your actual OpenAI API key. You can set the `model` parameter to the desired version of GPT (e.g., `gpt-4o`).
 
+### Ollama Configuration
+
+To use Ollama, configure the file as follows:
+
+```ini
+[openai]
+api_key = ollama
+model = gemma2
+base_url = http://localhost:11434/v1/
+```
+
 ## Usage
 
 Generating a changelog and updating your `CHANGELOG.md` file is straightforward. Navigate to your Git repository directory and run:

--- a/gptchangelog/__init__.py
+++ b/gptchangelog/__init__.py
@@ -179,7 +179,7 @@ def load_openai_config(config_file_name="config.ini"):
 
     config = configparser.ConfigParser()
     config.read(config_file)
-    return config["openai"]["api_key"], config["openai"].get("model", "gpt-4o")
+    return config["openai"]["api_key"], config["openai"].get("model", "gpt-4o"), config["openai"].get("base_url", "https://api.openai.com/v1")
 
 
 def main():
@@ -201,9 +201,10 @@ def main():
     # Parse the arguments
     args = parser.parse_args()
 
-    api_key, model = load_openai_config()
+    api_key, model, base_url = load_openai_config()
 
     openai.api_key = api_key
+    openai.base_url = base_url
 
     latest_commit = args.since
     if latest_commit is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ h11==0.14.0
 httpcore==1.0.2
 httpx==0.25.1
 idna==3.4
-openai==1.3.4
+openai==1.35.7
 pydantic==2.5.2
 pydantic_core==2.14.5
 smmap==5.0.1


### PR DESCRIPTION
### Changes
- Modified the `load_openai_config` function to return `base_url` from the configuration file.

### Reason for Change
- The existing `load_openai_config` function did not return `base_url`, making it impossible to read the base URL from the configuration file.
- This caused issues when setting the default URL for Ollama API calls.

### Modifications
- Updated the `load_openai_config` function to include the `base_url` entry when reading from the configuration file.

### Testing
- Added the `base_url` entry to the configuration file and verified that the `load_openai_config` function correctly returns the `base_url`.

### Additional Notes
- This change is necessary to ensure the correct URL is set for Ollama API or OpenAI Proxy API calls.
